### PR TITLE
consolidate pr-summary into pr-create skill

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,8 @@
+<!--
+Editors: if you change this template, update the inline copy in skills/pr-create/SKILL.md.
+The pr-create agent skill inlines this template so it doesn't need a runtime fetch.
+-->
+
 ## ℹ️ Overview
 
 **REPLACE ME**: Provide the context and description of the change.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,3 @@
-<!--
-Editors: if you change this template, update the inline copy in skills/pr-create/SKILL.md.
-The pr-create agent skill inlines this template so it doesn't need a runtime fetch.
--->
-
 ## ℹ️ Overview
 
 **REPLACE ME**: Provide the context and description of the change.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ You can then ask an AI agent to create a PR, or call the skill directly in the p
 ```sh
 /pr-create
 ```
+
+The skill drafts a PR summary from the branch's diff (title, overview, test instructions, risks) and offers to create a new PR or update an existing one.

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -87,9 +87,35 @@ Use the live template fetched above. For each section it contains, apply this gu
 
 ### Output format
 
-Output the title in its own fenced markdown code block, then each template section in its own fenced markdown code block. Triple backticks with `markdown` language tag. Label each block with a bold heading outside the fence (eg `**Title**`, `**Overview**`) matching the section name in the template. Do not include the section heading (eg `## ℹ️ Overview`) inside the code block — the bold label outside serves that purpose. No other preamble or commentary.
+Output the title in its own fenced markdown code block, then each section from the fetched template in its own fenced markdown code block. This lets the user copy-paste each section independently into GitHub.
 
-This lets the user copy-paste each section independently into GitHub.
+Rules:
+
+- Triple backticks with `markdown` language tag on every block.
+- Label each block with a bold heading **outside** the fence (eg `**Title**`, `**Overview**`) using the section name from the fetched template.
+- Do not include the template's section heading (eg `## ℹ️ Overview`) inside the code block — the bold label outside serves that purpose.
+- No preamble or commentary between blocks.
+
+Use this format for every section in the fetched template, in template order. Example for the Title and an Overview section:
+
+**Title**
+
+````
+```markdown
+<concise title>
+```
+````
+
+**Overview**
+
+````
+```markdown
+- <bullet>
+- <bullet>
+```
+````
+
+Apply the same pattern to whichever sections the current template contains (Test Instructions, Test Results, Risks, etc).
 
 ### Offer to publish
 

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -1,17 +1,43 @@
 ---
 name: pr-create
-description: Create a pull request (PR) with our standard GitHub PR template
+description: Draft a PR summary for the current branch and create or update the PR using our standard GitHub PR template
 ---
 
 ## Goal
 
-Create a pull request (PR) for the current git branch by filling out our standard template.
+Draft a pull request summary for the current git branch using our standard template, then create the PR or update an existing one.
 
-When this skill fails without a fix, ask the user to manually create a PR via the GitHub UI after pushing their branch.
+When this skill fails without a fix (eg `gh` not installed, push rejected), ask the user to push the branch and create the PR manually via the GitHub UI.
+
+## Audience and tone
+
+PR descriptions are read by humans doing code review, not by LLMs or as exhaustive change logs. Optimize for the reviewer's attention budget.
+
+- Brevity beats completeness. A reviewer should be able to read the whole description in under 30 seconds and know what to look at in the diff.
+- Plain language, lowercase is fine, no marketing voice. Match the author's tone.
+- No padding: skip context the diff already shows, skip restating what the title says, skip "this PR does X by Y" preamble.
+- No LLM trope sentences ("it's not just X, it's Y", "comprehensive", "robust", "seamlessly"). Cut adjectives.
+- Bullets over prose. One line per bullet. If a bullet wraps to three lines, it's two bullets or it's too long.
+- Explain the non-obvious "why" (a constraint, a trade-off considered, a thing that looks wrong but isn't). Skip the obvious "what" the diff already conveys.
+- When in doubt, cut. A shorter description that nails the key risk is better than a longer one that buries it.
+- Do not describe or justify changes you considered but did not make. If it's not in the diff, the reviewer doesn't need it. No "left X as-is on purpose" or "considered Y but didn't". That's conversation context, not PR content.
+- Each Overview bullet should be "what changed, why in one short clause". Do not enumerate field names, timing measurements, severity levels, or other specifics the diff already shows. The reviewer reads the diff for details; the bullet's job is to point them at it.
+
+**Calibration example** — same change, two versions:
+
+Too long:
+- removed `<thing>` from `<file>`. it was a strict subset of `<other thing>` (which already carries `<field>`, `<field>`, `<field>`) and fired ~Nms later.
+- demoted `<other thing>` to debug. <one-sentence justification about volume/usefulness>.
+
+Right size:
+- removed `<thing>` from `<file>`, as it now duplicates `<other thing>`
+- demoted `<other thing>` to debug
+
+The trimmed version drops field lists, quantitative details, and extra justifying clauses — all derivable from the diff or obvious from context. The "why" survives as a single short clause.
 
 ## PR Template
 
-The canonical pull request template is available in the public GitHub `UseAlloy/.github` repository:
+The canonical pull request template lives in this public `UseAlloy/.github` repository:
 
 https://github.com/UseAlloy/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md
 
@@ -24,34 +50,124 @@ export PR_TEMPLATE=$(gh api \
 )
 ```
 
+The sections below match this template.
+
+## Instructions
+
+1. **Analyze the actual changes on the branch** (this is the single source of truth, not conversation history):
+
+   ```sh
+   git log origin/master..HEAD --oneline
+   git diff origin/master...HEAD --stat
+   git diff origin/master...HEAD
+   ```
+
+   Read the full diff carefully. Every claim in the summary must be backed by something in the diff. Do not describe changes that were discussed but not committed, or changes that were made and then reverted.
+
+2. **Conversation context is secondary.** If this runs within an existing chat session, the conversation may explain _why_ a change was made or what trade-offs were considered. Use that for the "why", but never let it override what the diff actually shows. If the conversation mentions a change that isn't in the diff, do not include it.
+
+3. **Generate a PR title:** concise, descriptive.
+
+4. **Generate summary** by filling in these sections (matching the template):
+
+   - **Overview:** replace the "REPLACE ME" placeholder with what changed and why. Short bullets, not prose. 3-5 bullets max, one line each. Skip obvious context the diff conveys, focus on intent and non-obvious decisions.
+   - **Test Instructions:** only steps a reviewer actually needs to run. Skip "clone the repo" style setup. 3-5 steps max. If none can be accurately defined, tell the user to fill this in as a next step after the PR is created.
+   - **Test Results** (optional): include only when you have actual results, screenshots, recordings, or query outputs to share. Otherwise omit the section entirely.
+   - **Risks:** check `[x]` only for real risks from: Authentication/authorization, Data privacy, Networking, Major configuration, Other core setup. Add context below the checkbox list. If none apply, write one short line eg "No significant risks - [brief reason]". If you cannot accurately assess risks, tell the user to fill this in as a next step.
+
+   **Length target:** full summary readable in under 30 seconds. If you're writing more, cut the least important detail first. Default to the shorter version.
+
+5. **Output each section in its own fenced code block** (triple backticks with `markdown` language tag) so the user can copy-paste each section independently into GitHub. Label each block with a bold heading outside the fence (eg `**Title**`). Do not include the section heading (eg `## ℹ️ Overview`) inside the code block. No other preamble or commentary.
+
+6. **Formatting rules:**
+
+   - Bullets over prose in Overview and Test Instructions.
+   - For Risks: include only `[x]` checked lines (omit unchecked categories). Put any additional notes BELOW the checkbox list.
+
+7. **Use this exact template** (each section in its own fenced code block):
+
+**Title**
+
+````
+```markdown
+<concise title>
+```
+````
+
+**Overview**
+
+````
+```markdown
+<description here>
+```
+````
+
+**Test Instructions**
+
+````
+```markdown
+1. <specific step>
+2. <specific step>
+3. <specific step>
+```
+````
+
+**Test Results** (optional)
+
+````
+```markdown
+<only include this section if you have actual results to share; omit entirely otherwise>
+```
+````
+
+**Risks**
+
+````
+```markdown
+<only include [x] checked lines for applicable risks from: Authentication/authorization, Data privacy, Networking, Major configuration, Other core setup>
+<add context about the risk below>
+<if no risks apply, just write: "No significant risks - [brief reason]">
+```
+````
+
+8. **Offer to publish.** After displaying the summary, ask the user if they'd like to:
+
+   - **Create a new PR** (see [PR Creation](#pr-creation) below)
+   - **Update an existing PR:** user provides the PR number, then run `gh pr edit <number>` to set the title and body
+   - **Do nothing:** they'll handle it themselves
+
+   Let the user know to review the generated PR description and walk through the Authoring Guidelines section in the template before marking ready for review.
+
 ## PR Creation
 
-The `gh` CLI should be available on all developer machines. If it's not, it can be installed via Homebrew:
+The `gh` CLI should be available on all developer machines. If not, install via Homebrew:
 
-```
+```sh
 brew install gh
 ```
 
-First the branch must be pushed up:
+Push the branch first:
 
 ```sh
 git push --set-upstream origin HEAD
 ```
 
-Then a PR can be created with this command:
+Then create the PR as a draft:
 
 ```sh
 gh pr create --title '{TITLE}' --body '{BODY}' --draft
 ```
 
+Use a HEREDOC for the body to preserve formatting:
+
+```sh
+gh pr create --title "the pr title" --draft --body "$(cat <<'EOF'
+<body here>
+EOF
+)"
+```
+
 Replace the placeholders:
 
-- `{TITLE}`: PR title should be a concise yet descriptive title for the branch's changes.
-- `{BODY}`: PR body should use the [PR Template](#pr-template) and fill in the details as outlined in the template itself.
-
-## Guidelines
-
-- Replace the "REPLACE ME" placeholder in the Overview section with a concise 1-2 sentence description of the overall changes, e.g: Updates the core authentication code to support additional clients. When available, provide context for why the changes are being made.
-- Fill in the test instructions in the Test Instructions section, providing commands to run and/or pages to test for QA. If none can be accurately defined, let the user know to do this as a next step after the PR is creted.
-- Try to fill out the Risks section by checking a box with `[x]`. If none can be accurately defined, let the user know to do this as a next step after the PR is creted.
-- As part of next steps, let the user know they need to review the generated PR description and go through the Authoring Guidelines section.
+- `{TITLE}`: concise yet descriptive title for the branch's changes.
+- `{BODY}`: PR body using the [PR Template](#pr-template), filled in per the [Instructions](#instructions) above.

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -37,63 +37,20 @@ The trimmed version drops field lists, quantitative details, and extra justifyin
 
 ## PR Template
 
-This is a literal copy of the canonical [PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md). Use it as the PR body verbatim, filling in only the dynamic sections (Overview, Test Instructions, Test Results, Risks) per the guidance below. Do not invent, reorder, or rename sections.
+The canonical pull request template lives in this public `UseAlloy/.github` repository:
 
-> If you change the template, change this inline copy too. They live in the same repo so the diff stays in one PR.
+https://github.com/UseAlloy/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md
 
-````markdown
-## ℹ️ Overview
+Fetch it in a shell to get the live section list and headings:
 
-**REPLACE ME**: Provide the context and description of the change.
+```sh
+export PR_TEMPLATE=$(gh api \
+  --header 'Accept: application/vnd.github.v3.raw' \
+  'repos/UseAlloy/.github/contents/.github/PULL_REQUEST_TEMPLATE.md'
+)
+```
 
-## 🧪 Test Instructions
-
-Here are the steps to verify the change works as expected and does not introduce regressions.
-
-1. 
-2. 
-3. 
-
-### Test Results
-
-Here are the testing results with relevant screenshots, screen recordings, query outputs, etc.
-
-## 📝 Authoring Guidelines
-
-> [!TIP]
-> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#23205351a8d28009b535d9218306a268).
-
-As the author, I verify that I have:
-
-- [ ] Followed the test instructions and updated the test results.
-- [ ] Added/updated unit tests as applicable.
-- [ ] Added/updated documentation as applicable.
-
-## 💬 Reviewer Guidelines
-
-> [!TIP]
-> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#24705351a8d2802998f6e5e0612bfd4c).
-
-Reviewers are responsible for:
-
-- Reading the full PR description.
-- Evaluating all code changes, including edge cases and regressions.
-- Testing the change (locally or in ephemeral environments, if applicable).
-- Leaving thoughtful, actionable feedback.
-- Clearly signaling approval or requesting changes.
-
-## 🚨 Risks
-
-There may be possible side effects or negative impacts from these changes:
-
-- [ ] Authentication and/or authorization
-- [ ] Data privacy
-- [ ] Networking
-- [ ] Major configuration
-- [ ] Other core setup (please clarify below)
-````
-
-The Authoring Guidelines and Reviewer Guidelines sections are static — include them in the body as-is, unchanged.
+Fill in this template — do not invent or reorder sections. The per-section authoring guidance below applies to whichever sections the template currently contains.
 
 ## Drafting the PR
 
@@ -119,7 +76,7 @@ Concise and descriptive. Do not prefix or include the ticket ID — the branch n
 
 ### Fill in the template sections
 
-Apply this guidance to the dynamic sections:
+Use the live template fetched above. For each section it contains, apply this guidance where relevant:
 
 - **Overview** — replace the "REPLACE ME" placeholder with what changed and why. Short bullets, not prose. 3-5 bullets max, one line each. Skip obvious context the diff conveys, focus on intent and non-obvious decisions.
 - **Test Instructions** — only steps a reviewer actually needs to run. Skip "clone the repo" style setup. 3-5 steps max. If none can be accurately defined, tell the user to fill this in as a next step after the PR is created.
@@ -130,17 +87,16 @@ Apply this guidance to the dynamic sections:
 
 ### Output format
 
-Output the title in its own fenced markdown code block, then each dynamic section (Overview, Test Instructions, optionally Test Results, Risks) in its own fenced markdown code block. This lets the user copy-paste each section independently into GitHub.
+Output the title in its own fenced markdown code block, then each section from the fetched template in its own fenced markdown code block. This lets the user copy-paste each section independently into GitHub.
 
 Rules:
 
 - Triple backticks with `markdown` language tag on every block.
-- Label each block with a bold heading **outside** the fence (eg `**Title**`, `**Overview**`) matching the template section name.
+- Label each block with a bold heading **outside** the fence (eg `**Title**`, `**Overview**`) using the section name from the fetched template.
 - Do not include the template's section heading (eg `## ℹ️ Overview`) inside the code block — the bold label outside serves that purpose.
 - No preamble or commentary between blocks.
-- Do not output blocks for Authoring Guidelines or Reviewer Guidelines — those are static and don't need user attention per-PR.
 
-Example:
+Use this format for every section in the fetched template, in template order. Example for the Title and an Overview section:
 
 **Title**
 
@@ -159,7 +115,7 @@ Example:
 ```
 ````
 
-(Apply the same pattern to Test Instructions, Test Results if applicable, and Risks.)
+Apply the same pattern to whichever sections the current template contains (Test Instructions, Test Results, Risks, etc).
 
 ### Offer to publish
 
@@ -185,42 +141,22 @@ Push the branch first:
 git push --set-upstream origin HEAD
 ```
 
-Then create the PR as a draft. The body is the full [PR Template](#pr-template) with the dynamic sections filled in (Authoring Guidelines and Reviewer Guidelines stay as-is).
+Then create the PR as a draft:
+
+```sh
+gh pr create --title '{TITLE}' --body '{BODY}' --draft
+```
 
 Use a HEREDOC for the body to preserve formatting:
 
 ```sh
 gh pr create --title "the pr title" --draft --body "$(cat <<'EOF'
-## ℹ️ Overview
-
-- <filled-in bullet>
-- <filled-in bullet>
-
-## 🧪 Test Instructions
-
-1. <step>
-2. <step>
-
-### Test Results
-
-<results or leave empty>
-
-## 📝 Authoring Guidelines
-
-<static — copy from the template above unchanged>
-
-## 💬 Reviewer Guidelines
-
-<static — copy from the template above unchanged>
-
-## 🚨 Risks
-
-- [x] <only checked categories>
-
-<context about the risk>
+<body here>
 EOF
 )"
 ```
 
-- Title: concise, descriptive (no ticket ID).
-- Body: the [PR Template](#pr-template) above, with dynamic sections filled in per [Drafting the PR](#drafting-the-pr).
+Replace the placeholders:
+
+- `{TITLE}`: concise, descriptive title for the branch's changes (no ticket ID).
+- `{BODY}`: PR body using the fetched [PR Template](#pr-template), filled in per [Drafting the PR](#drafting-the-pr).

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -37,20 +37,63 @@ The trimmed version drops field lists, quantitative details, and extra justifyin
 
 ## PR Template
 
-The canonical pull request template lives in this public `UseAlloy/.github` repository:
+This is a literal copy of the canonical [PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md). Use it as the PR body verbatim, filling in only the dynamic sections (Overview, Test Instructions, Test Results, Risks) per the guidance below. Do not invent, reorder, or rename sections.
 
-https://github.com/UseAlloy/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+> If you change the template, change this inline copy too. They live in the same repo so the diff stays in one PR.
 
-Fetch it in a shell to get the live section list and headings:
+````markdown
+## ℹ️ Overview
 
-```sh
-export PR_TEMPLATE=$(gh api \
-  --header 'Accept: application/vnd.github.v3.raw' \
-  'repos/UseAlloy/.github/contents/.github/PULL_REQUEST_TEMPLATE.md'
-)
-```
+**REPLACE ME**: Provide the context and description of the change.
 
-Fill in this template — do not invent or reorder sections. The per-section authoring guidance below applies to whichever sections the template currently contains.
+## 🧪 Test Instructions
+
+Here are the steps to verify the change works as expected and does not introduce regressions.
+
+1. 
+2. 
+3. 
+
+### Test Results
+
+Here are the testing results with relevant screenshots, screen recordings, query outputs, etc.
+
+## 📝 Authoring Guidelines
+
+> [!TIP]
+> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#23205351a8d28009b535d9218306a268).
+
+As the author, I verify that I have:
+
+- [ ] Followed the test instructions and updated the test results.
+- [ ] Added/updated unit tests as applicable.
+- [ ] Added/updated documentation as applicable.
+
+## 💬 Reviewer Guidelines
+
+> [!TIP]
+> Read through our full [PR Guidelines](https://www.notion.so/alloy/PR-Guidelines-22c05351a8d280c898d8c8a0b486d96d#24705351a8d2802998f6e5e0612bfd4c).
+
+Reviewers are responsible for:
+
+- Reading the full PR description.
+- Evaluating all code changes, including edge cases and regressions.
+- Testing the change (locally or in ephemeral environments, if applicable).
+- Leaving thoughtful, actionable feedback.
+- Clearly signaling approval or requesting changes.
+
+## 🚨 Risks
+
+There may be possible side effects or negative impacts from these changes:
+
+- [ ] Authentication and/or authorization
+- [ ] Data privacy
+- [ ] Networking
+- [ ] Major configuration
+- [ ] Other core setup (please clarify below)
+````
+
+The Authoring Guidelines and Reviewer Guidelines sections are static — include them in the body as-is, unchanged.
 
 ## Drafting the PR
 
@@ -76,7 +119,7 @@ Concise and descriptive. Do not prefix or include the ticket ID — the branch n
 
 ### Fill in the template sections
 
-Use the live template fetched above. For each section it contains, apply this guidance where relevant:
+Apply this guidance to the dynamic sections:
 
 - **Overview** — replace the "REPLACE ME" placeholder with what changed and why. Short bullets, not prose. 3-5 bullets max, one line each. Skip obvious context the diff conveys, focus on intent and non-obvious decisions.
 - **Test Instructions** — only steps a reviewer actually needs to run. Skip "clone the repo" style setup. 3-5 steps max. If none can be accurately defined, tell the user to fill this in as a next step after the PR is created.
@@ -87,16 +130,17 @@ Use the live template fetched above. For each section it contains, apply this gu
 
 ### Output format
 
-Output the title in its own fenced markdown code block, then each section from the fetched template in its own fenced markdown code block. This lets the user copy-paste each section independently into GitHub.
+Output the title in its own fenced markdown code block, then each dynamic section (Overview, Test Instructions, optionally Test Results, Risks) in its own fenced markdown code block. This lets the user copy-paste each section independently into GitHub.
 
 Rules:
 
 - Triple backticks with `markdown` language tag on every block.
-- Label each block with a bold heading **outside** the fence (eg `**Title**`, `**Overview**`) using the section name from the fetched template.
+- Label each block with a bold heading **outside** the fence (eg `**Title**`, `**Overview**`) matching the template section name.
 - Do not include the template's section heading (eg `## ℹ️ Overview`) inside the code block — the bold label outside serves that purpose.
 - No preamble or commentary between blocks.
+- Do not output blocks for Authoring Guidelines or Reviewer Guidelines — those are static and don't need user attention per-PR.
 
-Use this format for every section in the fetched template, in template order. Example for the Title and an Overview section:
+Example:
 
 **Title**
 
@@ -115,7 +159,7 @@ Use this format for every section in the fetched template, in template order. Ex
 ```
 ````
 
-Apply the same pattern to whichever sections the current template contains (Test Instructions, Test Results, Risks, etc).
+(Apply the same pattern to Test Instructions, Test Results if applicable, and Risks.)
 
 ### Offer to publish
 
@@ -141,22 +185,42 @@ Push the branch first:
 git push --set-upstream origin HEAD
 ```
 
-Then create the PR as a draft:
-
-```sh
-gh pr create --title '{TITLE}' --body '{BODY}' --draft
-```
+Then create the PR as a draft. The body is the full [PR Template](#pr-template) with the dynamic sections filled in (Authoring Guidelines and Reviewer Guidelines stay as-is).
 
 Use a HEREDOC for the body to preserve formatting:
 
 ```sh
 gh pr create --title "the pr title" --draft --body "$(cat <<'EOF'
-<body here>
+## ℹ️ Overview
+
+- <filled-in bullet>
+- <filled-in bullet>
+
+## 🧪 Test Instructions
+
+1. <step>
+2. <step>
+
+### Test Results
+
+<results or leave empty>
+
+## 📝 Authoring Guidelines
+
+<static — copy from the template above unchanged>
+
+## 💬 Reviewer Guidelines
+
+<static — copy from the template above unchanged>
+
+## 🚨 Risks
+
+- [x] <only checked categories>
+
+<context about the risk>
 EOF
 )"
 ```
 
-Replace the placeholders:
-
-- `{TITLE}`: concise, descriptive title for the branch's changes (no ticket ID).
-- `{BODY}`: PR body using the fetched [PR Template](#pr-template), filled in per [Drafting the PR](#drafting-the-pr).
+- Title: concise, descriptive (no ticket ID).
+- Body: the [PR Template](#pr-template) above, with dynamic sections filled in per [Drafting the PR](#drafting-the-pr).

--- a/skills/pr-create/SKILL.md
+++ b/skills/pr-create/SKILL.md
@@ -41,7 +41,7 @@ The canonical pull request template lives in this public `UseAlloy/.github` repo
 
 https://github.com/UseAlloy/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md
 
-It can be fetched in a shell like this:
+Fetch it in a shell to get the live section list and headings:
 
 ```sh
 export PR_TEMPLATE=$(gh api \
@@ -50,93 +50,56 @@ export PR_TEMPLATE=$(gh api \
 )
 ```
 
-The sections below match this template.
+Fill in this template — do not invent or reorder sections. The per-section authoring guidance below applies to whichever sections the template currently contains.
 
-## Instructions
+## Drafting the PR
 
-1. **Analyze the actual changes on the branch** (this is the single source of truth, not conversation history):
+### Analyze the actual changes on the branch
 
-   ```sh
-   git log origin/master..HEAD --oneline
-   git diff origin/master...HEAD --stat
-   git diff origin/master...HEAD
-   ```
+This is the single source of truth, not conversation history.
 
-   Read the full diff carefully. Every claim in the summary must be backed by something in the diff. Do not describe changes that were discussed but not committed, or changes that were made and then reverted.
-
-2. **Conversation context is secondary.** If this runs within an existing chat session, the conversation may explain _why_ a change was made or what trade-offs were considered. Use that for the "why", but never let it override what the diff actually shows. If the conversation mentions a change that isn't in the diff, do not include it.
-
-3. **Generate a PR title:** concise, descriptive.
-
-4. **Generate summary** by filling in these sections (matching the template):
-
-   - **Overview:** replace the "REPLACE ME" placeholder with what changed and why. Short bullets, not prose. 3-5 bullets max, one line each. Skip obvious context the diff conveys, focus on intent and non-obvious decisions.
-   - **Test Instructions:** only steps a reviewer actually needs to run. Skip "clone the repo" style setup. 3-5 steps max. If none can be accurately defined, tell the user to fill this in as a next step after the PR is created.
-   - **Test Results** (optional): include only when you have actual results, screenshots, recordings, or query outputs to share. Otherwise omit the section entirely.
-   - **Risks:** check `[x]` only for real risks from: Authentication/authorization, Data privacy, Networking, Major configuration, Other core setup. Add context below the checkbox list. If none apply, write one short line eg "No significant risks - [brief reason]". If you cannot accurately assess risks, tell the user to fill this in as a next step.
-
-   **Length target:** full summary readable in under 30 seconds. If you're writing more, cut the least important detail first. Default to the shorter version.
-
-5. **Output each section in its own fenced code block** (triple backticks with `markdown` language tag) so the user can copy-paste each section independently into GitHub. Label each block with a bold heading outside the fence (eg `**Title**`). Do not include the section heading (eg `## ℹ️ Overview`) inside the code block. No other preamble or commentary.
-
-6. **Formatting rules:**
-
-   - Bullets over prose in Overview and Test Instructions.
-   - For Risks: include only `[x]` checked lines (omit unchecked categories). Put any additional notes BELOW the checkbox list.
-
-7. **Use this exact template** (each section in its own fenced code block):
-
-**Title**
-
-````
-```markdown
-<concise title>
+```sh
+git log origin/master..HEAD --oneline
+git diff origin/master...HEAD --stat
+git diff origin/master...HEAD
 ```
-````
 
-**Overview**
+Read the full diff carefully. Every claim in the summary must be backed by something in the diff. Do not describe changes that were discussed but not committed, or changes that were made and then reverted.
 
-````
-```markdown
-<description here>
-```
-````
+### Conversation context is secondary
 
-**Test Instructions**
+If this runs within an existing chat session, the conversation may explain _why_ a change was made or what trade-offs were considered. Use that for the "why", but never let it override what the diff actually shows. If the conversation mentions a change that isn't in the diff, do not include it.
 
-````
-```markdown
-1. <specific step>
-2. <specific step>
-3. <specific step>
-```
-````
+### Generate a PR title
 
-**Test Results** (optional)
+Concise and descriptive. Do not prefix or include the ticket ID — the branch name already carries it. The PR title should describe the change, not duplicate the branch metadata.
 
-````
-```markdown
-<only include this section if you have actual results to share; omit entirely otherwise>
-```
-````
+### Fill in the template sections
 
-**Risks**
+Use the live template fetched above. For each section it contains, apply this guidance where relevant:
 
-````
-```markdown
-<only include [x] checked lines for applicable risks from: Authentication/authorization, Data privacy, Networking, Major configuration, Other core setup>
-<add context about the risk below>
-<if no risks apply, just write: "No significant risks - [brief reason]">
-```
-````
+- **Overview** — replace the "REPLACE ME" placeholder with what changed and why. Short bullets, not prose. 3-5 bullets max, one line each. Skip obvious context the diff conveys, focus on intent and non-obvious decisions.
+- **Test Instructions** — only steps a reviewer actually needs to run. Skip "clone the repo" style setup. 3-5 steps max. If none can be accurately defined, tell the user to fill this in as a next step after the PR is created.
+- **Test Results** — include only when you have actual results, screenshots, recordings, or query outputs to share. Otherwise leave the section empty or omit per the template's convention.
+- **Risks** — check `[x]` only for real risks (omit unchecked categories from your output). Add context below the checkbox list. If none apply, write one short line eg "No significant risks - [brief reason]". If you cannot accurately assess risks, tell the user to fill this in as a next step.
 
-8. **Offer to publish.** After displaying the summary, ask the user if they'd like to:
+**Length target:** full summary readable in under 30 seconds. If you're writing more, cut the least important detail first. Default to the shorter version.
 
-   - **Create a new PR** (see [PR Creation](#pr-creation) below)
-   - **Update an existing PR:** user provides the PR number, then run `gh pr edit <number>` to set the title and body
-   - **Do nothing:** they'll handle it themselves
+### Output format
 
-   Let the user know to review the generated PR description and walk through the Authoring Guidelines section in the template before marking ready for review.
+Output the title in its own fenced markdown code block, then each template section in its own fenced markdown code block. Triple backticks with `markdown` language tag. Label each block with a bold heading outside the fence (eg `**Title**`, `**Overview**`) matching the section name in the template. Do not include the section heading (eg `## ℹ️ Overview`) inside the code block — the bold label outside serves that purpose. No other preamble or commentary.
+
+This lets the user copy-paste each section independently into GitHub.
+
+### Offer to publish
+
+After displaying the summary, ask the user if they'd like to:
+
+- **Create a new PR** (see [PR Creation](#pr-creation) below)
+- **Update an existing PR** — user provides the PR number, then run `gh pr edit <number>` to set the title and body
+- **Do nothing** — they'll handle it themselves
+
+Let the user know to review the generated PR description and walk through the Authoring Guidelines section in the template before marking ready for review.
 
 ## PR Creation
 
@@ -169,5 +132,5 @@ EOF
 
 Replace the placeholders:
 
-- `{TITLE}`: concise yet descriptive title for the branch's changes.
-- `{BODY}`: PR body using the [PR Template](#pr-template), filled in per the [Instructions](#instructions) above.
+- `{TITLE}`: concise, descriptive title for the branch's changes (no ticket ID).
+- `{BODY}`: PR body using the fetched [PR Template](#pr-template), filled in per [Drafting the PR](#drafting-the-pr).


### PR DESCRIPTION
## ℹ️ Overview

merges the Alloy monorepo's `pr-summary` command into this `pr-create` skill so we have one canonical PR-authoring skill across the org. ticket: [EE-1627](https://team-alloy.atlassian.net/browse/EE-1627).

- `pr-create` now drafts a PR summary from the branch diff (title, overview, test instructions, risks) before creating or updating the PR
- adds audience/tone guidance, diff-as-source-of-truth rule, calibration example, and fenced-code-block output for copy-paste
- keeps existing pr-create behavior: standard template, `--draft` default, HEREDOC body, manual UI fallback
- README gets one short line noting the skill drafts a summary in addition to creating the PR

skill name and slug unchanged (`pr-create`), so existing `gh skill install UseAlloy/.github pr-create` and `/pr-create` keep working.

## 🧪 Test Instructions

1. `gh skill install UseAlloy/.github pr-create` (or re-install if already present) and confirm `.agents/skills/pr-create/SKILL.md` reflects the merged content
2. on a feature branch with real changes, invoke `/pr-create` in your AI agent
3. verify the agent: reads the diff, produces title + Overview/Test Instructions/Risks in fenced markdown blocks, then offers to create a new PR or update an existing one
4. accept "create new PR" and confirm a draft PR is opened with the template populated

## 🚨 Risks

- [x] Other core setup (please clarify below)

low risk. only changes the skill content and the README. skill slug is unchanged so existing install/invoke commands keep working. no template, workflow, or CODEOWNERS changes.

[EE-1627]: https://team-alloy.atlassian.net/browse/EE-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ