### PR TITLE
feat: add reusable PR description check workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 ## ℹ️ Overview
+<!-- Do not remove this section: the pr-description-check workflow uses it to validate that the PR description includes a non-empty summary with enough context for reviewers. -->
 
 **REPLACE ME**: Provide the context and description of the change.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## ℹ️ Overview
-<!-- Do not remove this section: the pr-description-check workflow uses it to validate that the PR description includes a non-empty summary with enough context for reviewers. -->
+<!-- The Overview section must be present and filled out: the pr-description-check workflow uses it to validate that the PR description includes a non-empty summary with enough context for reviewers. -->
 
 **REPLACE ME**: Provide the context and description of the change.
 

--- a/.github/scripts/validate-pr-description.js
+++ b/.github/scripts/validate-pr-description.js
@@ -5,9 +5,26 @@
  * @param {{ core: import('@actions/core'), context: import('@actions/github').Context }} params
  * @param {{ minOverviewLength?: number }} options
  */
+/**
+ * Revert PRs are exempt from description validation. Detection lives here rather than
+ * in a workflow `if` condition so the job still completes successfully instead of
+ * showing as skipped, which can block merges when this check is required.
+ */
+function isRevertPr(pr) {
+  const title = pr?.title ?? '';
+  const headRef = pr?.head?.ref ?? '';
+  return /^Revert\s/i.test(title) || /^revert[-_]/i.test(headRef);
+}
+
 module.exports = async function validatePrDescription({ core, context }, options = {}) {
   const minOverviewLength = Number(options.minOverviewLength) || 40;
   const pr = context.payload.pull_request;
+
+  if (isRevertPr(pr)) {
+    core.info('Skipping PR description check for revert PR.');
+    return;
+  }
+
   const body = pr?.body ?? '';
 
   if (!body.trim()) {
@@ -15,7 +32,7 @@ module.exports = async function validatePrDescription({ core, context }, options
     return;
   }
 
-  if (/\*\*REPLACE ME\*\*/i.test(body)) {
+  if (/\*\*REPLACE ME\*\*/.test(body)) {
     core.setFailed('PR description still contains the "REPLACE ME" placeholder. Please fill in the overview.');
     return;
   }

--- a/.github/scripts/validate-pr-description.js
+++ b/.github/scripts/validate-pr-description.js
@@ -1,0 +1,48 @@
+/**
+ * Validate that a PR description has a filled Overview section.
+ * Intended for use with actions/github-script.
+ *
+ * @param {{ core: import('@actions/core'), context: import('@actions/github').Context }} params
+ * @param {{ minOverviewLength?: number }} options
+ */
+module.exports = async function validatePrDescription({ core, context }, options = {}) {
+  const minOverviewLength = Number(options.minOverviewLength) || 40;
+  const pr = context.payload.pull_request;
+  const body = pr?.body ?? '';
+
+  if (!body.trim()) {
+    core.setFailed('PR description is empty. Please add a description with enough context for reviewers.');
+    return;
+  }
+
+  if (/\*\*REPLACE ME\*\*/i.test(body)) {
+    core.setFailed('PR description still contains the "REPLACE ME" placeholder. Please fill in the overview.');
+    return;
+  }
+
+  const withoutComments = body.replace(/<!--[\s\S]*?-->/g, '');
+  const overviewSection = withoutComments
+    .split(/\n(?=## )/)
+    .find((section) => /^##[^\n]*overview/i.test(section.trim()));
+
+  if (!overviewSection) {
+    core.setFailed(
+      'PR description must include an "## Overview" section. Use the standard PR template and fill in the overview.'
+    );
+    return;
+  }
+
+  const overviewText = overviewSection
+    .replace(/^##[^\n]*\n?/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (overviewText.length < minOverviewLength) {
+    core.setFailed(
+      `Overview section is too short (${overviewText.length} characters, minimum ${minOverviewLength}). Please add a brief description of the change.`
+    );
+    return;
+  }
+
+  core.info(`PR description check passed (overview: ${overviewText.length} characters).`);
+};

--- a/.github/workflows/callable.pr-description-check.yaml
+++ b/.github/workflows/callable.pr-description-check.yaml
@@ -1,0 +1,43 @@
+name: pr-description-check
+on:
+  workflow_call:
+    inputs:
+      min_overview_length:
+        description: Minimum character count required in the Overview section after stripping HTML comments and placeholders.
+        type: number
+        required: false
+        default: 40
+    secrets:
+      GH_TOKEN:
+        required: true
+
+jobs:
+  pr-description-check:
+    name: PR description check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v7
+        with:
+          # Check out the reusable workflow's own repo/SHA so callers get the
+          # script version that matches the pinned callable workflow.
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Validate PR description
+        uses: actions/github-script@v9
+        env:
+          MIN_OVERVIEW_LENGTH: ${{ inputs.min_overview_length }}
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const script = require('${{ github.workspace }}/.github/scripts/validate-pr-description.js');
+            // github, context, and core are injected by github-script from this
+            // job's runtime context (the caller's workflow run / PR payload).
+            await script(
+              { github, context, core },
+              { minOverviewLength: Number(process.env.MIN_OVERVIEW_LENGTH) || 40 }
+            );

--- a/.github/workflows/callable.pr-description-check.yaml
+++ b/.github/workflows/callable.pr-description-check.yaml
@@ -40,5 +40,5 @@ jobs:
             // Revert PRs (title "Revert ..." or revert-* branch) are exempt — see validate-pr-description.js.
             await script(
               { github, context, core },
-              { minOverviewLength: Number(process.env.MIN_OVERVIEW_LENGTH) || 40 }
+              { minOverviewLength: Number(process.env.MIN_OVERVIEW_LENGTH) }
             );

--- a/.github/workflows/callable.pr-description-check.yaml
+++ b/.github/workflows/callable.pr-description-check.yaml
@@ -37,6 +37,7 @@ jobs:
             const script = require('${{ github.workspace }}/.github/scripts/validate-pr-description.js');
             // github, context, and core are injected by github-script from this
             // job's runtime context (the caller's workflow run / PR payload).
+            // Revert PRs (title "Revert ..." or revert-* branch) are exempt — see validate-pr-description.js.
             await script(
               { github, context, core },
               { minOverviewLength: Number(process.env.MIN_OVERVIEW_LENGTH) || 40 }

--- a/.github/workflows/local.pr-description-check.yaml
+++ b/.github/workflows/local.pr-description-check.yaml
@@ -5,8 +5,6 @@ on:
       - opened
       - edited
       - reopened
-      - labeled
-      - unlabeled
 
 
 jobs:

--- a/.github/workflows/local.pr-description-check.yaml
+++ b/.github/workflows/local.pr-description-check.yaml
@@ -6,7 +6,6 @@ on:
       - edited
       - reopened
 
-
 jobs:
   call-pr-description-check-workflow:
     uses: ./.github/workflows/callable.pr-description-check.yaml

--- a/.github/workflows/local.pr-description-check.yaml
+++ b/.github/workflows/local.pr-description-check.yaml
@@ -1,0 +1,16 @@
+name: pr-description-check
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+
+
+jobs:
+  call-pr-description-check-workflow:
+    uses: ./.github/workflows/callable.pr-description-check.yaml
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## ℹ️ Overview

- add callable and local PR description check workflows to UseAlloy/.github
- extract Overview validation into `.github/scripts/validate-pr-description.js`
- callable checks out scripts via `job.workflow_repository` / `job.workflow_sha` so consumer repos get the pinned script version
- exempt revert PRs from description validation (detected by `Revert ...` title or `revert-*` branch name); handled in-script so required checks still pass instead of showing skipped
- add PR template comment documenting that the Overview section must be present and filled out (used by CI validation)
- local workflow runs on `opened`, `edited`, and `reopened` only (not label changes)

Relates to [INFR-6089](https://team-alloy.atlassian.net/browse/INFR-6089).

## 🤖 Coding AI Authorship

- [ ] Human-authored: written almost entirely by hand; maybe some autocomplete, sourced code or scaffolding.
- [x] Co-authored: agent wrote meaningful portions, significantly edited by me.
- [ ] AI-authored: nearly all agent-authored with minimal human edits if any.
Operator directed, reviewed, and revised; AI implemented the workflow and script changes.

## 🧪 Test Instructions

1. Merge this PR
2. Wire a consumer repo to `UseAlloy/.github/.github/workflows/callable.pr-description-check.yaml@<ref>` (or enable the local workflow in this repo)
3. Open a PR with a filled Overview — check should pass
4. Open a revert PR (title `Revert ...`) — check should pass without requiring Overview content
5. Failed run: https://github.com/UseAlloy/.github/actions/runs/32899598921
6. Successful run: https://github.com/UseAlloy/.github/actions/runs/32902795183

### Test Results

Successful run verified on this PR.

## 📝 Authoring Guidelines

As the author, I verify that I have:

- [x] Followed the test instructions and updated the test results.
- [ ] Added/updated unit tests as applicable.
- [x] Added/updated documentation as applicable.

## 🚨 Risks

Shared callable workflow — consuming repos must reference this repo (not org-workflows) for the PR description check. Missing `job.workflow_*` fails checkout by design.

[INFR-6089]: https://team-alloy.atlassian.net/browse/INFR-6089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ